### PR TITLE
Added tryByName.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,11 @@
   },
 
   "require": {
-    "php": "^5.4 || ^7.0",
-
+    "php": "^7.2",
     "ext-json": "*"
   },
 
   "require-dev": {
-    "phpunit/phpunit": "~4.8"
+    "phpunit/phpunit": ">=8.5.8"
   }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -45,9 +45,9 @@ abstract class Enum implements JsonSerializable
      * For example:
      *
      * ```
-     * Fruit::byName('APPLE'); // Fruit::APPLE()
-     * Fruit::byName('BANANA'); // Fruit::BANANA()
-     * Fruit::byName('UNKNOWN'); // null
+     * Fruit::tryByName('APPLE'); // Fruit::APPLE()
+     * Fruit::tryByName('BANANA'); // Fruit::BANANA()
+     * Fruit::tryByName('UNKNOWN'); // null
      * ```
      *
      * @param string $name

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -33,18 +33,42 @@ abstract class Enum implements JsonSerializable
 
     /**
      * @param string $name
-     *
-     * @throws Enum\Exception\InvalidInstance
      */
     private function __construct($name)
     {
-        $constants = static::getAllNames();
+        $this->constName = $name;
+    }
 
-        if (in_array($name, $constants)) {
-            $this->constName = $name;
-        } else {
-            throw new Enum\Exception\InvalidInstance(get_called_class(), $name);
+    /**
+     * Attempts to instantiate an Enum from a label name, or return null if the name is not valid.
+     *
+     * For example:
+     *
+     * ```
+     * Fruit::byName('APPLE'); // Fruit::APPLE()
+     * Fruit::byName('BANANA'); // Fruit::BANANA()
+     * Fruit::byName('UNKNOWN'); // null
+     * ```
+     *
+     * @param string $name
+     *
+     * @return null|static
+     */
+    final public static function tryByName($name)
+    {
+        $instances = &static::getInstances();
+
+        if (!array_key_exists($name, $instances)) {
+            $constants = static::getAllNames();
+
+            if (!in_array($name, $constants)) {
+                return null;
+            }
+
+            $instances[$name] = new static($name);
         }
+
+        return $instances[$name];
     }
 
     /**
@@ -66,13 +90,13 @@ abstract class Enum implements JsonSerializable
      */
     final public static function byName($name)
     {
-        $instances = &static::getInstances();
+        $instance = self::tryByName($name);
 
-        if (!array_key_exists($name, $instances)) {
-            $instances[$name] = new static($name);
+        if ($instance === null) {
+            throw new Enum\Exception\InvalidInstance(get_called_class(), $name);
         }
 
-        return $instances[$name];
+        return $instance;
     }
 
     /**
@@ -233,7 +257,6 @@ abstract class Enum implements JsonSerializable
      */
     final public function when(Enum $a, $b)
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $map = new Enum\Matcher($this);
 
         return $map->when($a, $b);
@@ -290,7 +313,6 @@ abstract class Enum implements JsonSerializable
      */
     final public function whenDo(Enum $a, $b)
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $map = new Enum\Matcher($this);
 
         return $map->whenDo($a, $b);

--- a/tests/Enum/MatcherTest.php
+++ b/tests/Enum/MatcherTest.php
@@ -3,18 +3,19 @@
 namespace Vcn\Lib\Enum;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Vcn\Lib\Enum;
 use Vcn\Lib\EnumTest\Fruit;
 use Vcn\Lib\EnumTest\Vegetables;
 
-class MatcherTest extends PHPUnit_Framework_TestCase
+class MatcherTest extends TestCase
 {
     /**
      * @test
      */
     public function testGet()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
 
         $matcher
@@ -23,7 +24,6 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(0, $matcher->get());
 
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::SPINACH());
 
         $matcher
@@ -32,7 +32,6 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(1, $matcher->get());
 
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::SPINACH());
 
         $matcher
@@ -44,17 +43,16 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \Vcn\Lib\Enum\Matcher\Exception\MatchExhausted
      */
     public function testGetOnIncompleteMap()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::SPINACH());
 
-        $matcher
-            ->when(Vegetables::CAULIFLOWER(), 0);
+        $this->expectException(Enum\Matcher\Exception\MatchExhausted::class);
 
-        $matcher->get();
+        $matcher
+            ->when(Vegetables::CAULIFLOWER(), 0)
+            ->get();
     }
 
     /**
@@ -62,7 +60,6 @@ class MatcherTest extends PHPUnit_Framework_TestCase
      */
     public function testOrElse()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
 
         $matcher
@@ -70,7 +67,6 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(0, $matcher->orElse(1));
 
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::SPINACH());
 
         $matcher
@@ -84,7 +80,6 @@ class MatcherTest extends PHPUnit_Framework_TestCase
      */
     public function testOrElseDo()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
 
         $actual =
@@ -98,7 +93,6 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame(0, $actual);
 
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::SPINACH());
 
         $actual =
@@ -115,12 +109,12 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function testOrElseDoWithValue()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
+
+        $this->expectException(InvalidArgumentException::class);
 
         /** @noinspection PhpParamsInspection */
         $matcher
@@ -129,12 +123,12 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function testInconsistentMap()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
+
+        $this->expectException(InvalidArgumentException::class);
 
         $matcher
             ->when(Vegetables::CAULIFLOWER(), 0)
@@ -143,12 +137,12 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function testDoubleMap()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
+
+        $this->expectException(InvalidArgumentException::class);
 
         $matcher
             ->when(Vegetables::CAULIFLOWER(), 0)
@@ -157,12 +151,12 @@ class MatcherTest extends PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function testDoubleMapWithNull()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
+
+        $this->expectException(InvalidArgumentException::class);
 
         $matcher
             ->when(Vegetables::CAULIFLOWER(), null)
@@ -172,55 +166,11 @@ class MatcherTest extends PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function testWhenDo()
-    {
-        /** @noinspection PhpInternalEntityUsedInspection */
-        $matcher = new Matcher(Vegetables::CAULIFLOWER());
-
-        $matcher
-            ->whenDo(
-                Vegetables::CAULIFLOWER(),
-                function () {
-                    return 0;
-                }
-            )
-            ->whenDo(
-                Vegetables::SPINACH(),
-                function () {
-                    throw new Exception('This should not be evaluated.');
-                }
-            );
-
-        $this->assertSame(0, $matcher->get());
-    }
-
-    /**
-     * @test
-     */
-    public function testOrElseDoNothing()
-    {
-
-        /** @noinspection PhpInternalEntityUsedInspection */
-        $matcher = new Matcher(Vegetables::CAULIFLOWER());
-
-        $matcher
-            ->whenDo(
-                Vegetables::SPINACH(),
-                function () {
-                    throw new Exception('This should not be evaluated.');
-                }
-            )
-            ->orElseDoNothing();
-    }
-
-    /**
-     * @test
-     * @expectedException \InvalidArgumentException
-     */
     public function testWhenDoOnValue()
     {
-        /** @noinspection PhpInternalEntityUsedInspection */
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
+
+        $this->expectException(InvalidArgumentException::class);
 
         /** @noinspection PhpParamsInspection */
         $matcher

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -1,24 +1,39 @@
 <?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+
 namespace Vcn\Lib;
 
-use PHPUnit_Framework_Error_Warning;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use Vcn\Lib\Enum\Exception;
 use Vcn\Lib\EnumTest\Color;
 use Vcn\Lib\EnumTest\Fruit;
 use Vcn\Lib\EnumTest\Silly;
 use Vcn\Lib\EnumTest\Vegetables;
 
-class EnumTest extends \PHPUnit_Framework_TestCase
+class EnumTest extends TestCase
 {
     /**
      * @test
-     * @throws Enum\Exception\InvalidInstance
      */
     public function testSingletonInstances()
     {
         $this->assertSame(Fruit::BANANA(), Fruit::BANANA());
         $this->assertSame(Vegetables::byName('SPINACH'), Vegetables::byName('SPINACH'));
         $this->assertSame(Color::BLUE(), Color::byName('BLUE'));
+    }
+
+    /**
+     * @test
+     */
+    public function testTryByName()
+    {
+        $this->assertSame("CAULIFLOWER", Vegetables::tryByName("CAULIFLOWER")->getName());
+        $this->assertSame("SPINACH", Vegetables::tryByName("SPINACH")->getName());
+        $this->assertSame("APPLE", Fruit::tryByName("APPLE")->getName());
+        $this->assertSame("BANANA", Fruit::tryByName("BANANA")->getName());
+        $this->assertSame(null, Fruit::tryByName("CAULIFLOWER"));
     }
 
     /**
@@ -47,11 +62,12 @@ class EnumTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \Vcn\Lib\Enum\Exception\InvalidInstance
      */
     public function testNonExistingName()
     {
         $nonExistingName = implode('', Vegetables::getAllNames());
+
+        $this->expectException(Exception\InvalidInstance::class);
 
         Vegetables::byName($nonExistingName);
     }
@@ -141,38 +157,42 @@ class EnumTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function testEqualsNotWorkingOnTwoDifferentEnums()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         Vegetables::SPINACH()->equals(Fruit::BANANA());
     }
 
     /**
      * @test
-     * @expectedException \Vcn\Lib\Enum\Exception\InvalidInstance
      */
     public function testInvalidEnum()
     {
+        $this->expectException(Exception\InvalidInstance::class);
+
         /** @noinspection PhpUndefinedMethodInspection */
         Vegetables::INVALID();
     }
 
     /**
      * @test
-     * @expectedException PHPUnit_Framework_Error_Warning
      */
     public function testInheritThenInheritAgainProducesWarning()
     {
+        $this->expectWarning();
+
         Silly::GOOSE();
     }
 
     /**
      * @test
-     * @expectedException PHPUnit_Framework_Error_Warning
      */
     public function testInheritThenInheritAgainProducesWarning2()
     {
+        $this->expectWarning();
+
         Silly::CAULIFLOWER();
     }
 }


### PR DESCRIPTION
Added a `tryByName` method, like `byName`, except error handling is performed at call site, rather than in a catch block.

Also,

- Dropped support for PHP 5.x, 7.0, 7.1.
- Updated phpunit and tests.