### PR TITLE
Fixed unit tests

### DIFF
--- a/tests/Enum/MatcherTest.php
+++ b/tests/Enum/MatcherTest.php
@@ -5,6 +5,7 @@ namespace Vcn\Lib\Enum;
 use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use TypeError;
 use Vcn\Lib\Enum;
 use Vcn\Lib\EnumTest\Fruit;
 use Vcn\Lib\EnumTest\Vegetables;
@@ -114,7 +115,7 @@ class MatcherTest extends TestCase
     {
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(TypeError::class);
 
         /** @noinspection PhpParamsInspection */
         $matcher
@@ -170,7 +171,7 @@ class MatcherTest extends TestCase
     {
         $matcher = new Matcher(Vegetables::CAULIFLOWER());
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(TypeError::class);
 
         /** @noinspection PhpParamsInspection */
         $matcher


### PR DESCRIPTION
In https://github.com/vcn/enum/pull/3, callable was introduced as parameter type for `Matcher::orElseDo(...)` and `Matcher::whenDo(...)`. Before, the code would check the type manually and throw an InvalidArgumentException. Since that pull request, not providing a callable would trigger a TypeError instead. The unit tests were still expecting an InvalidArgumentException. With these changes, they now expect a TypeError instead.