### PR TITLE
Fix PHPStan inference when matching to a union of types

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: 8
+    paths:
+        - tests/PHPStan/

--- a/src/Enum/Matcher.php
+++ b/src/Enum/Matcher.php
@@ -48,10 +48,12 @@ final class Matcher
     }
 
     /**
-     * @phpstan-param TEnum $enum
-     * @phpstan-param callable(): TResult $callable
+     * @template UResult
      *
-     * @phpstan-return Matcher<TEnum, TResult>
+     * @phpstan-param TEnum $enum
+     * @phpstan-param callable(): TResult|UResult $callable
+     *
+     * @phpstan-return Matcher<TEnum, TResult|UResult>
      *
      * @return Matcher
      */
@@ -110,10 +112,12 @@ final class Matcher
      *
      * `'apple'` if `$fruit = Fruit::APPLE()`
      *
-     * @phpstan-param TEnum $enum
-     * @phpstan-param TResult $value
+     * @template UResult
      *
-     * @phpstan-return Matcher<TEnum, TResult>
+     * @phpstan-param TEnum $enum
+     * @phpstan-param TResult|UResult $value
+     *
+     * @phpstan-return Matcher<TEnum, TResult|UResult>
      *
      * @param Enum  $enum  The Enum instance, must be an instance of the subject of this map.
      * @param mixed $value The value to map the given instance to.
@@ -170,10 +174,12 @@ final class Matcher
      * It is <strong>discouraged</strong> to throw checked exceptions since PHPStorm can't infer the corresponding
      * throws clauses on relevant methods.
      *
-     * @phpstan-param TEnum $enum
-     * @phpstan-param callable(): TResult $callable
+     * @template UResult
      *
-     * @phpstan-return Matcher<TEnum, TResult>
+     * @phpstan-param TEnum $enum
+     * @phpstan-param callable(): (TResult|UResult) $callable
+     *
+     * @phpstan-return Matcher<TEnum, TResult|UResult>
      *
      * @return Matcher
      */
@@ -226,8 +232,10 @@ final class Matcher
      *
      * `'Some other fruit I did not know about?' if $fruit = Fruit::EGGPLANT();`
      *
-     * @phpstan-param TResult $value
-     * @phpstan-return TResult
+     * @template UResult
+     *
+     * @phpstan-param TResult|UResult $value
+     * @phpstan-return TResult|UResult
      *
      * @param mixed $value The surrogate value to return if the instance has not been mapped to anything
      *
@@ -279,8 +287,10 @@ final class Matcher
      * It is <strong>discouraged</strong> to throw checked exceptions since PHPStorm can't infer the corresponding
      * throws clause on this method.
      *
-     * @phpstan-param callable(): TResult $callable
-     * @phpstan-return TResult
+     * @template UResult
+     *
+     * @phpstan-param callable(): TResult|UResult $callable
+     * @phpstan-return TResult|UResult
      *
      * @param callable $callable
      *
@@ -294,7 +304,7 @@ final class Matcher
     /**
      * `Matcher::orElseDo` passing `noop`.
      *
-     * @phpstan-return TResult
+     * @phpstan-return null|TResult
      *
      * @return mixed
      */

--- a/tests/PHPStan/InferenceTest.php
+++ b/tests/PHPStan/InferenceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/** @noinspection PhpStatementHasEmptyBodyInspection */
+
+namespace Vcn\Lib\PHPStan;
+
+use stdClass;
+use Vcn\Lib\EnumTest\Color;
+
+class InferenceTest
+{
+    public function test(): void
+    {
+        $red = Color::RED();
+        $val =
+            $red
+                ->when(Color::RED(), 'red')
+                ->when(Color::RED(), 1)
+                ->when(Color::RED(), null)
+                ->whenDo(Color::RED(), fn () => true)
+                ->orElse(new stdClass());
+
+        if (is_string($val)) {
+        } elseif (is_int($val)) {
+        } elseif (is_null($val)) {
+        } elseif (is_bool($val)) {
+        } elseif ($val instanceof stdClass) {
+        }
+
+        $val =
+            $red
+                ->when(Color::RED(), 'red')
+                ->when(Color::RED(), 1)
+                ->when(Color::RED(), null)
+                ->whenDo(Color::RED(), fn () => true)
+                ->orElseDo(fn () => new stdClass());
+
+        if (is_string($val)) {
+        } elseif (is_int($val)) {
+        } elseif (is_null($val)) {
+        } elseif (is_bool($val)) {
+        } elseif ($val instanceof stdClass) {
+        }
+
+        $val =
+            $red
+                ->when(Color::RED(), 'red')
+                ->when(Color::RED(), 1)
+                ->whenDo(Color::RED(), fn () => true)
+                ->orElseDoNothing();
+
+        if (is_string($val)) {
+        } elseif (is_int($val)) {
+        } elseif (is_null($val)) {
+        } elseif (is_bool($val)) {
+        }
+    }
+}


### PR DESCRIPTION
When matching to several different types:

```
$c
    ->when(Color::RED(), 'red')
    ->orElse(null);
```

PHPStan complains that the type of the second value must unify with the type of the first:

```
> Parameter #1 $value of method Vcn\Lib\Enum\Matcher<Color,string>::orElse() expects string, null given.
```

Instead, these methods should allow for a different type, that is then added to the earlier types. That is, `$val` in the block:

```
$red = Color::RED();
$val =
    $red
        ->when(Color::RED(), 'red')
        ->when(Color::RED(), 1)
        ->when(Color::RED(), null)
        ->whenDo(Color::RED(), fn () => true)
        ->orElse(new stdClass());

\PHPStan\dumpType($val);
```

should have inferred for it all the possible types:

```
> Dumped type: bool|int|stdClass|string|null
```

The changed type signatures fix this.