### PR TITLE
Fixed "Unable to resolve the template type UResult in ..." errors.

### DIFF
--- a/src/Enum/Matcher.php
+++ b/src/Enum/Matcher.php
@@ -51,7 +51,7 @@ final class Matcher
      * @template UResult
      *
      * @phpstan-param TEnum $enum
-     * @phpstan-param callable(): TResult|UResult $callable
+     * @phpstan-param callable(): UResult $callable
      *
      * @phpstan-return Matcher<TEnum, TResult|UResult>
      *
@@ -115,7 +115,7 @@ final class Matcher
      * @template UResult
      *
      * @phpstan-param TEnum $enum
-     * @phpstan-param TResult|UResult $value
+     * @phpstan-param UResult $value
      *
      * @phpstan-return Matcher<TEnum, TResult|UResult>
      *
@@ -177,7 +177,7 @@ final class Matcher
      * @template UResult
      *
      * @phpstan-param TEnum $enum
-     * @phpstan-param callable(): (TResult|UResult) $callable
+     * @phpstan-param callable(): UResult $callable
      *
      * @phpstan-return Matcher<TEnum, TResult|UResult>
      *
@@ -189,7 +189,9 @@ final class Matcher
     }
 
     /**
-     * @phpstan-param callable(): TResult $callable
+     * @template UResult
+     *
+     * @phpstan-param callable(): UResult $callable
      * @phpstan-return TResult
      *
      * @return mixed
@@ -234,7 +236,7 @@ final class Matcher
      *
      * @template UResult
      *
-     * @phpstan-param TResult|UResult $value
+     * @phpstan-param UResult $value
      * @phpstan-return TResult|UResult
      *
      * @param mixed $value The surrogate value to return if the instance has not been mapped to anything
@@ -289,7 +291,7 @@ final class Matcher
      *
      * @template UResult
      *
-     * @phpstan-param callable(): TResult|UResult $callable
+     * @phpstan-param callable(): UResult $callable
      * @phpstan-return TResult|UResult
      *
      * @param callable $callable

--- a/tests/PHPStan/InferenceTest.php
+++ b/tests/PHPStan/InferenceTest.php
@@ -22,7 +22,7 @@ class InferenceTest
 
         if (is_string($val)) {
         } elseif (is_int($val)) {
-        } elseif (is_null($val)) {
+        } elseif ($val === null) {
         } elseif (is_bool($val)) {
         } elseif ($val instanceof stdClass) {
         }
@@ -37,7 +37,7 @@ class InferenceTest
 
         if (is_string($val)) {
         } elseif (is_int($val)) {
-        } elseif (is_null($val)) {
+        } elseif ($val === null) {
         } elseif (is_bool($val)) {
         } elseif ($val instanceof stdClass) {
         }
@@ -51,8 +51,46 @@ class InferenceTest
 
         if (is_string($val)) {
         } elseif (is_int($val)) {
-        } elseif (is_null($val)) {
+        } elseif ($val === null) {
         } elseif (is_bool($val)) {
+        }
+    }
+
+    public function test2(bool $v): void
+    {
+        $red = Color::RED();
+        $val =
+            $red
+                ->when(Color::RED(), 'red')
+                ->when(Color::RED(), 1)
+                ->when(Color::RED(), $v ? 'red' : 1)
+                ->orElse(null);
+
+        if (is_string($val)) {
+        } elseif (is_int($val)) {
+        } elseif ($val === null) {
+        }
+
+        $val =
+            $red
+                ->when(Color::RED(), 'red')
+                ->when(Color::RED(), 1)
+                ->whenDo(Color::RED(), fn () => $v ? 'red' : 1)
+                ->orElse(null);
+
+        if (is_string($val)) {
+        } elseif (is_int($val)) {
+        } elseif ($val === null) {
+        }
+
+        $val =
+            $red
+                ->when(Color::RED(), 'red')
+                ->when(Color::RED(), 1)
+                ->orElse($v ? 'red' : 1);
+
+        if (is_string($val)) {
+        } elseif (is_int($val)) {
         }
     }
 }


### PR DESCRIPTION
Fixes some inference issues with calls such as `Enum<E, A|B>::when(A|B $value)` for fixed `A` and `B`.