### PR TITLE
Test PHP8.1 compatibility (CLIP-1466)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
-/phpunit/
 /reports/
+.phpunit.result.cache
 composer.lock
+phpstan.neon

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 VCN Verzekerings Combinatie Nederland B.V.
+Copyright (c) 2022 VCN Verzekerings Combinatie Nederland B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
 
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "phpstan/phpstan": "^0.12.63"
+    "phpstan/phpstan": "^1.2"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,4 @@
 parameters:
-    level: 8
+    level: max
     paths:
         - tests/PHPStan/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Vcn\Lib\Enum TestSuite">
-            <file>tests/EnumTest.php</file>
-            <file>tests/Enum/MatcherTest.php</file>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Vcn\Lib\Enum TestSuite">
+      <file>tests/EnumTest.php</file>
+      <file>tests/Enum/MatcherTest.php</file>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
PHP 8.1 introduces native enums, this PR proves that it doesn't appear to be problematic with our current enum and we don't need to change it to make it work on ^php81.
Also executed the phpunit `--migrate-configuration`.

Run (edit the volume path to your project path)
`docker run -v /home/roy/Projects/enum:/srv -w /srv/ docker.vcn.ninja/php81:cli-dev php vendor/bin/phpstan`

`docker run -v /home/roy/Projects/enum:/srv -w /srv/ docker.vcn.ninja/php81:cli-dev php vendor/bin/phpunit`

:tada: