### PR TITLE
Fix PHP 8.1 deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
   },
 
   "require": {
-    "php": "^7.4|^8.0",
+    "php": "^8.0",
     "ext-json": "*"
   },
 
   "require-dev": {
     "phpunit/phpunit": "^9.5",
-    "phpstan/phpstan": "^1.2"
+    "phpstan/phpstan": "^1.4"
   }
 }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -451,7 +451,7 @@ abstract class Enum implements JsonSerializable
     /**
      * @inheritdoc
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->getName();
     }


### PR DESCRIPTION
Minor change to add `: mixed` as return type for the jsonSerialize to prevent deprecation warnings. Requires PHP 8.0 or higher.

Run (edit the volume path to your project path)
`docker run -v /home/roy/Projects/enum:/srv -w /srv/ docker.vcn.ninja/php81:cli-dev php vendor/bin/phpstan`

`docker run -v /home/roy/Projects/enum:/srv -w /srv/ docker.vcn.ninja/php81:cli-dev php vendor/bin/phpunit`

Patch tag please.