### PR TITLE
Abandon package because we can now use PHP native enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,9 @@
 {
   "name": "vcn/enum",
   "type": "library",
-  "description": "Enumeration data types with pattern match operations.",
+  "description": "[Deprecated] Enumeration data types with pattern match operations. This package is obsolete because PHP has native enums now.",
   "license": "MIT",
+  "abandoned": true,
 
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Title is self-explanatory. PHP 8.1 introduces enums, which means this package is no longer needed.